### PR TITLE
Disable instant popup on mobile

### DIFF
--- a/src/app/success/newsFormSuccess.css
+++ b/src/app/success/newsFormSuccess.css
@@ -53,7 +53,7 @@
       border: none;
       padding: 50px;
       border-radius: 10px; /* Reduced border radius */
-      display: flex;
+      display: none;
       flex-direction: column; /* Added to ensure proper layout on small screens */
     }
   


### PR DESCRIPTION
On mobile devices, popup would be seen immediately. Forgot to add "display: none" in media queries